### PR TITLE
Support for spawning test vehicle with 100% fuel level.

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -72,6 +72,8 @@ function StartDriveTest(type)
 
 		local playerPed   = PlayerPedId()
 		TaskWarpPedIntoVehicle(playerPed, vehicle, -1)
+		SetVehicleFuelLevel(vehicle, 100.0)
+		DecorSetFloat(vehicle, "_FUEL_LEVEL", GetVehicleFuelLevel(vehicle))
 	end)
 
 	TriggerServerEvent('esx_dmvschool:pay', Config.Prices[type])


### PR DESCRIPTION
* Changes to spawn test vehicle with 100% fuel level.
* Code replicated from LegacyFuel SetFuel function.
* Based on changes from #45 but using Native FiveM functions.